### PR TITLE
Wizard: fix misleading "Save Draft" link that discarded user input

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -480,6 +480,66 @@ class ApplicationStep5Form(forms.ModelForm):
         return cleaned_data
 
 
+# =============================================================================
+# Draft variants of the wizard step forms (partial-save mode)
+# =============================================================================
+#
+# The wizard's "Save Draft" button posts action=save_draft. The view picks
+# the matching *Draft form below, which loosens required-field validation
+# and skips strict cross-field business rules so an applicant can persist
+# whatever they have typed without first completing the step. The regular
+# Next button still uses the full forms and validates as before.
+
+
+class _DraftFormMixin:
+    """Mark every bound field optional so partial input can be saved."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.required = False
+
+
+class ApplicationStep1DraftForm(_DraftFormMixin, ApplicationStep1Form):
+    pass
+
+
+class ApplicationStep2DraftForm(_DraftFormMixin, ApplicationStep2Form):
+    def clean(self):
+        # Bypass ApplicationStep2Form.clean() (which requires a name/origin
+        # when "Other" is selected). Run only the base ModelForm clean(),
+        # then drop the "Other" sentinel so the FK doesn't try to persist it.
+        cleaned_data = forms.ModelForm.clean(self)
+        agency = cleaned_data.get('funding_agency_obj')
+        if agency == FundingAgencyWithOtherChoiceField.OTHER_SENTINEL:
+            cleaned_data['funding_agency_obj'] = None
+        return cleaned_data
+
+    def save(self, commit=True):
+        # Bypass ApplicationStep2Form.save() which derives project_type from
+        # the funding agency; on a draft save we just persist what the form
+        # already has on the instance.
+        instance = forms.ModelForm.save(self, commit=False)
+        if commit:
+            instance.save()
+        return instance
+
+
+class ApplicationStep3DraftForm(_DraftFormMixin, ApplicationStep3Form):
+    pass
+
+
+class ApplicationStep4DraftForm(_DraftFormMixin, ApplicationStep4Form):
+    pass
+
+
+class ApplicationStep5DraftForm(_DraftFormMixin, ApplicationStep5Form):
+    def clean(self):
+        # Skip ApplicationStep5Form.clean() — drafts are not required to
+        # have data_consent ticked.
+        return forms.ModelForm.clean(self)
+
+
 class FeasibilityReviewForm(forms.ModelForm):
     """Feasibility review by node coordinator"""
 

--- a/applications/views.py
+++ b/applications/views.py
@@ -17,8 +17,20 @@ from .models import Application, RequestedAccess, FeasibilityReview
 from .forms import (
     ApplicationStep1Form, ApplicationStep2Form, ApplicationStep3Form,
     ApplicationStep4Form, ApplicationStep5Form, RequestedAccessFormSet,
+    ApplicationStep1DraftForm, ApplicationStep2DraftForm,
+    ApplicationStep3DraftForm, ApplicationStep4DraftForm,
+    ApplicationStep5DraftForm,
     FeasibilityReviewForm
 )
+
+
+DRAFT_SAVED_MSG = (
+    "Draft saved. You can return any time from My Applications to continue."
+)
+
+
+def _is_draft_save(request):
+    return request.method == 'POST' and request.POST.get('action') == 'save_draft'
 
 
 @login_required
@@ -294,8 +306,11 @@ def application_edit_step1(request, pk):
         status='draft'
     )
 
+    draft_mode = _is_draft_save(request)
+
     if request.method == 'POST':
-        form = ApplicationStep1Form(request.POST, instance=application, user=request.user)
+        form_cls = ApplicationStep1DraftForm if draft_mode else ApplicationStep1Form
+        form = form_cls(request.POST, instance=application, user=request.user)
 
         if form.is_valid():
             app = form.save(commit=False)
@@ -310,6 +325,9 @@ def application_edit_step1(request, pk):
             if user.orcid:
                 app.applicant_orcid = user.orcid
             app.save()
+            if draft_mode:
+                messages.success(request, DRAFT_SAVED_MSG)
+                return redirect('applications:my_applications')
             messages.success(request, "Step 1 saved. Continue to step 2.")
             return redirect('applications:edit_step2', pk=application.pk)
     else:
@@ -336,11 +354,17 @@ def application_edit_step2(request, pk):
         status='draft'
     )
 
+    draft_mode = _is_draft_save(request)
+
     if request.method == 'POST':
-        form = ApplicationStep2Form(request.POST, instance=application)
+        form_cls = ApplicationStep2DraftForm if draft_mode else ApplicationStep2Form
+        form = form_cls(request.POST, instance=application)
 
         if form.is_valid():
             form.save()
+            if draft_mode:
+                messages.success(request, DRAFT_SAVED_MSG)
+                return redirect('applications:my_applications')
             messages.success(request, "Step 2 saved. Continue to step 3.")
             return redirect('applications:edit_step3', pk=application.pk)
     else:
@@ -366,6 +390,8 @@ def application_edit_step3(request, pk):
         status='draft'
     )
 
+    draft_mode = _is_draft_save(request)
+
     if request.method == 'POST':
         # Fix INITIAL_FORMS to match forms that actually have database IDs.
         # Browser-side JS may remove existing forms and add new ones, leaving
@@ -379,12 +405,33 @@ def application_edit_step3(request, pk):
                 actual_initial += 1
         post_data[f'{prefix}-INITIAL_FORMS'] = str(actual_initial)
 
-        service_form = ApplicationStep3Form(post_data, instance=application)
+        service_form_cls = ApplicationStep3DraftForm if draft_mode else ApplicationStep3Form
+        service_form = service_form_cls(post_data, instance=application)
         access_formset = RequestedAccessFormSet(
             post_data,
             instance=application,
             form_kwargs={'call': application.call}
         )
+
+        if draft_mode:
+            # Equipment rows still require both fields filled to persist, but
+            # we relax the formset's "at least one row" rule so a user with
+            # no equipment yet can still save their service-modality choice.
+            access_formset.validate_min = False
+            service_ok = service_form.is_valid()
+            formset_ok = access_formset.is_valid()
+            if service_ok:
+                service_form.save()
+            if formset_ok:
+                access_formset.save()
+            messages.success(request, DRAFT_SAVED_MSG)
+            if not formset_ok:
+                messages.warning(
+                    request,
+                    "Some equipment rows were incomplete and were not saved. "
+                    "Complete or remove them before clicking Next."
+                )
+            return redirect('applications:my_applications')
 
         if service_form.is_valid() and access_formset.is_valid():
             service_form.save()
@@ -420,11 +467,17 @@ def application_edit_step4(request, pk):
         status='draft'
     )
 
+    draft_mode = _is_draft_save(request)
+
     if request.method == 'POST':
-        form = ApplicationStep4Form(request.POST, instance=application)
+        form_cls = ApplicationStep4DraftForm if draft_mode else ApplicationStep4Form
+        form = form_cls(request.POST, instance=application)
 
         if form.is_valid():
             form.save()
+            if draft_mode:
+                messages.success(request, DRAFT_SAVED_MSG)
+                return redirect('applications:my_applications')
             messages.success(request, "Step 4 saved. Continue to step 5 (final step).")
             return redirect('applications:edit_step5', pk=application.pk)
     else:
@@ -450,8 +503,11 @@ def application_edit_step5(request, pk):
         status='draft'
     )
 
+    draft_mode = _is_draft_save(request)
+
     if request.method == 'POST':
-        form = ApplicationStep5Form(request.POST, instance=application, user=request.user)
+        form_cls = ApplicationStep5DraftForm if draft_mode else ApplicationStep5Form
+        form = form_cls(request.POST, instance=application, user=request.user)
 
         if form.is_valid():
             app = form.save(commit=False)
@@ -459,6 +515,9 @@ def application_edit_step5(request, pk):
             if request.user.auto_data_consent:
                 app.data_consent = True
             app.save()
+            if draft_mode:
+                messages.success(request, DRAFT_SAVED_MSG)
+                return redirect('applications:my_applications')
             messages.success(request, "All steps complete. Review and submit.")
             return redirect('applications:preview', pk=application.pk)
     else:

--- a/templates/applications/preview.html
+++ b/templates/applications/preview.html
@@ -264,8 +264,8 @@
             <a href="{% url 'applications:edit_step5' application.pk %}" class="btn btn-secondary">
                 <i class="bi bi-arrow-left"></i> Back to Edit
             </a>
-            <a href="{% url 'core:dashboard' %}" class="btn btn-outline-secondary btn-sm ms-2">
-                <i class="bi bi-save"></i> Save Draft Application
+            <a href="{% url 'applications:my_applications' %}" class="btn btn-outline-secondary btn-sm ms-2">
+                <i class="bi bi-box-arrow-left"></i> Save and Continue Later
             </a>
             <form method="post" action="{% url 'applications:cancel' application.pk %}" class="d-inline ms-2"
                   onsubmit="return confirm('Are you sure you want to cancel? All application data will be permanently deleted.');">

--- a/templates/applications/wizard_step1.html
+++ b/templates/applications/wizard_step1.html
@@ -123,8 +123,9 @@
 
                         <div class="alert alert-info">
                             <i class="bi bi-info-circle"></i>
-                            <strong>About this wizard:</strong> Your application will be saved as a draft at each step.
-                            You can return later to continue editing before final submission.
+                            <strong>About this wizard:</strong> Click <strong>Next</strong> to validate
+                            this step and save your progress. From step 2 onward you can also click
+                            <strong>Save Draft</strong> to save partial input and return later.
                         </div>
 
                         <div class="d-flex justify-content-between mt-4">

--- a/templates/applications/wizard_step2.html
+++ b/templates/applications/wizard_step2.html
@@ -144,22 +144,25 @@
 
                         <div class="alert alert-info">
                             <i class="bi bi-info-circle"></i>
-                            Your progress is automatically saved. You can return later to continue editing.
+                            Your progress is saved when you click <strong>Next</strong> (validates the step) or
+                            <strong>Save Draft</strong> (saves partial input).
                         </div>
 
                         <div class="d-flex justify-content-between mt-4">
                             <a href="{% url 'applications:edit_step1' application.pk %}" class="btn btn-secondary">
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
-                            <button type="submit" class="btn btn-primary">
-                                Next: Equipment Request <i class="bi bi-arrow-right"></i>
-                            </button>
+                            <div class="d-flex gap-2">
+                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                    <i class="bi bi-save"></i> Save Draft
+                                </button>
+                                <button type="submit" class="btn btn-primary">
+                                    Next: Equipment Request <i class="bi bi-arrow-right"></i>
+                                </button>
+                            </div>
                         </div>
                     </form>
                     <div class="d-flex gap-2 mt-2">
-                        <a href="{% url 'core:dashboard' %}" class="btn btn-outline-secondary btn-sm">
-                            <i class="bi bi-save"></i> Save Draft Application
-                        </a>
                         <form method="post" action="{% url 'applications:cancel' application.pk %}"
                               onsubmit="return confirm('Are you sure you want to cancel? All application data will be permanently deleted.');">
                             {% csrf_token %}

--- a/templates/applications/wizard_step2.html
+++ b/templates/applications/wizard_step2.html
@@ -153,7 +153,7 @@
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
                             <div class="d-flex gap-2">
-                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                <button type="submit" name="action" value="save_draft" formnovalidate class="btn btn-outline-secondary">
                                     <i class="bi bi-save"></i> Save Draft
                                 </button>
                                 <button type="submit" class="btn btn-primary">

--- a/templates/applications/wizard_step3.html
+++ b/templates/applications/wizard_step3.html
@@ -141,22 +141,25 @@
 
                         <div class="alert alert-info">
                             <i class="bi bi-info-circle"></i>
-                            Your progress is automatically saved. You can return later to continue editing.
+                            Your progress is saved when you click <strong>Next</strong> (validates the step) or
+                            <strong>Save Draft</strong> (saves partial input — incomplete equipment rows are skipped).
                         </div>
 
                         <div class="d-flex justify-content-between mt-4">
                             <a href="{% url 'applications:edit_step2' application.pk %}" class="btn btn-secondary">
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
-                            <button type="submit" class="btn btn-primary">
-                                Next: Scientific Content <i class="bi bi-arrow-right"></i>
-                            </button>
+                            <div class="d-flex gap-2">
+                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                    <i class="bi bi-save"></i> Save Draft
+                                </button>
+                                <button type="submit" class="btn btn-primary">
+                                    Next: Scientific Content <i class="bi bi-arrow-right"></i>
+                                </button>
+                            </div>
                         </div>
                     </form>
                     <div class="d-flex gap-2 mt-2">
-                        <a href="{% url 'core:dashboard' %}" class="btn btn-outline-secondary btn-sm">
-                            <i class="bi bi-save"></i> Save Draft Application
-                        </a>
                         <form method="post" action="{% url 'applications:cancel' application.pk %}"
                               onsubmit="return confirm('Are you sure you want to cancel? All application data will be permanently deleted.');">
                             {% csrf_token %}

--- a/templates/applications/wizard_step3.html
+++ b/templates/applications/wizard_step3.html
@@ -150,7 +150,7 @@
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
                             <div class="d-flex gap-2">
-                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                <button type="submit" name="action" value="save_draft" formnovalidate class="btn btn-outline-secondary">
                                     <i class="bi bi-save"></i> Save Draft
                                 </button>
                                 <button type="submit" class="btn btn-primary">

--- a/templates/applications/wizard_step4.html
+++ b/templates/applications/wizard_step4.html
@@ -115,7 +115,7 @@
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
                             <div class="d-flex gap-2">
-                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                <button type="submit" name="action" value="save_draft" formnovalidate class="btn btn-outline-secondary">
                                     <i class="bi bi-save"></i> Save Draft
                                 </button>
                                 <button type="submit" class="btn btn-primary">

--- a/templates/applications/wizard_step4.html
+++ b/templates/applications/wizard_step4.html
@@ -106,22 +106,25 @@
 
                         <div class="alert alert-info">
                             <i class="bi bi-info-circle"></i>
-                            Your progress is automatically saved. You can return later to continue editing.
+                            Your progress is saved when you click <strong>Next</strong> (validates the step) or
+                            <strong>Save Draft</strong> (saves partial input).
                         </div>
 
                         <div class="d-flex justify-content-between mt-4">
                             <a href="{% url 'applications:edit_step3' application.pk %}" class="btn btn-secondary">
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
-                            <button type="submit" class="btn btn-primary">
-                                Next: Declarations <i class="bi bi-arrow-right"></i>
-                            </button>
+                            <div class="d-flex gap-2">
+                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                    <i class="bi bi-save"></i> Save Draft
+                                </button>
+                                <button type="submit" class="btn btn-primary">
+                                    Next: Declarations <i class="bi bi-arrow-right"></i>
+                                </button>
+                            </div>
                         </div>
                     </form>
                     <div class="d-flex gap-2 mt-2">
-                        <a href="{% url 'core:dashboard' %}" class="btn btn-outline-secondary btn-sm">
-                            <i class="bi bi-save"></i> Save Draft Application
-                        </a>
                         <form method="post" action="{% url 'applications:cancel' application.pk %}"
                               onsubmit="return confirm('Are you sure you want to cancel? All application data will be permanently deleted.');">
                             {% csrf_token %}

--- a/templates/applications/wizard_step5.html
+++ b/templates/applications/wizard_step5.html
@@ -193,7 +193,7 @@
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
                             <div class="d-flex gap-2">
-                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                <button type="submit" name="action" value="save_draft" formnovalidate class="btn btn-outline-secondary">
                                     <i class="bi bi-save"></i> Save Draft
                                 </button>
                                 <button type="submit" class="btn btn-primary">

--- a/templates/applications/wizard_step5.html
+++ b/templates/applications/wizard_step5.html
@@ -192,15 +192,17 @@
                             <a href="{% url 'applications:edit_step4' application.pk %}" class="btn btn-secondary">
                                 <i class="bi bi-arrow-left"></i> Back
                             </a>
-                            <button type="submit" class="btn btn-primary">
-                                Next: Preview & Submit <i class="bi bi-arrow-right"></i>
-                            </button>
+                            <div class="d-flex gap-2">
+                                <button type="submit" name="action" value="save_draft" class="btn btn-outline-secondary">
+                                    <i class="bi bi-save"></i> Save Draft
+                                </button>
+                                <button type="submit" class="btn btn-primary">
+                                    Next: Preview & Submit <i class="bi bi-arrow-right"></i>
+                                </button>
+                            </div>
                         </div>
                     </form>
                     <div class="d-flex gap-2 mt-2">
-                        <a href="{% url 'core:dashboard' %}" class="btn btn-outline-secondary btn-sm">
-                            <i class="bi bi-save"></i> Save Draft Application
-                        </a>
                         <form method="post" action="{% url 'applications:cancel' application.pk %}"
                               onsubmit="return confirm('Are you sure you want to cancel? All application data will be permanently deleted.');">
                             {% csrf_token %}

--- a/tests/test_wizard_save_draft.py
+++ b/tests/test_wizard_save_draft.py
@@ -196,3 +196,15 @@ class WizardSaveDraftTests(TestCase):
         self.app.refresh_from_db()
         # Status should still be draft (not advanced).
         self.assertEqual(self.app.status, 'draft')
+
+    def test_save_draft_button_skips_html5_validation(self):
+        """Save Draft must carry `formnovalidate` so the browser doesn't
+        block the submit on required-but-blank fields (the regular form
+        renders each input with the `required` attribute)."""
+        for step_url_name in ('edit_step2', 'edit_step3', 'edit_step4', 'edit_step5'):
+            url = reverse(f'applications:{step_url_name}', kwargs={'pk': self.app.pk})
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 200, step_url_name)
+            html = resp.content.decode()
+            self.assertIn('name="action" value="save_draft"', html, step_url_name)
+            self.assertIn('formnovalidate', html, step_url_name)

--- a/tests/test_wizard_save_draft.py
+++ b/tests/test_wizard_save_draft.py
@@ -1,0 +1,198 @@
+"""
+Tests for the wizard's "Save Draft" action.
+
+Regression: applicants previously lost any unsaved input when clicking a fake
+"Save Draft Application" link that was just a dashboard nav (not a form
+submit). The button now POSTs action=save_draft to the current step view,
+which persists partial input through relaxed-validation form variants.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, Client, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from applications.models import Application, RequestedAccess
+from calls.models import Call, CallEquipmentAllocation
+from core.models import Organization, Node, Equipment
+
+User = get_user_model()
+
+
+def _make_call():
+    org = Organization.objects.create(
+        name='Org', country='ES', organization_type='university'
+    )
+    node = Node.objects.create(code='N1', organization=org, location='Madrid')
+    equipment = Equipment.objects.create(
+        node=node, name='MRI 7T', category='mri', area='preclinical'
+    )
+    call = Call.objects.create(
+        code='CALL-DRAFT', title='Draft Test',
+        submission_start=timezone.now() - timedelta(days=1),
+        submission_end=timezone.now() + timedelta(days=30),
+        evaluation_deadline=timezone.now() + timedelta(days=60),
+        execution_start=timezone.now() + timedelta(days=70),
+        execution_end=timezone.now() + timedelta(days=100),
+    )
+    CallEquipmentAllocation.objects.create(call=call, equipment=equipment)
+    return call, equipment
+
+
+@override_settings(
+    STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage'
+)
+class WizardSaveDraftTests(TestCase):
+    """Each step's Save Draft button persists partial input and redirects."""
+
+    def setUp(self):
+        org = Organization.objects.create(
+            name='Org', country='ES', organization_type='university'
+        )
+        self.user = User.objects.create_user(
+            username='applicant', email='a@test.com', password='x',
+            first_name='Aida', last_name='Test',
+            phone='+34 900 000 000',
+            organization=org,
+            position='Researcher',
+        )
+        self.call, self.equipment = _make_call()
+        self.app = Application.objects.create(
+            applicant=self.user, call=self.call, code='APP-DRAFT-1',
+            status='draft',
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_step2_save_draft_persists_partial_input(self):
+        """Brief description saves even though competitive-funding agency is missing."""
+        url = reverse('applications:edit_step2', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'action': 'save_draft',
+            'brief_description': 'partial summary, no agency yet',
+            'subject_area': '',
+            'has_competitive_funding': 'on',
+            'project_code': '',
+            'funding_agency_obj': '__other__',
+            'new_funding_agency_name': '',
+            'new_funding_agency_origin_of_funds': '',
+        })
+        self.assertRedirects(
+            resp, reverse('applications:my_applications'),
+            fetch_redirect_response=False,
+        )
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.brief_description, 'partial summary, no agency yet')
+        self.assertTrue(self.app.has_competitive_funding)
+        self.assertIsNone(self.app.funding_agency_obj)
+
+    def test_step2_next_still_enforces_validation(self):
+        """The Next path keeps the strict validation it always had."""
+        url = reverse('applications:edit_step2', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'brief_description': '',
+            'subject_area': '',
+            'has_competitive_funding': '',
+        })
+        # No redirect on validation failure — page re-renders with errors.
+        self.assertEqual(resp.status_code, 200)
+
+    def test_step3_save_draft_persists_service_modality(self):
+        """Service modality saves; an empty equipment formset is tolerated."""
+        url = reverse('applications:edit_step3', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'action': 'save_draft',
+            'service_modality': 'full_assistance',
+            'specialization_area': 'preclinical',
+            'requested_access-TOTAL_FORMS': '0',
+            'requested_access-INITIAL_FORMS': '0',
+            'requested_access-MIN_NUM_FORMS': '0',
+            'requested_access-MAX_NUM_FORMS': '1000',
+        })
+        self.assertRedirects(
+            resp, reverse('applications:my_applications'),
+            fetch_redirect_response=False,
+        )
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.service_modality, 'full_assistance')
+        self.assertEqual(self.app.specialization_area, 'preclinical')
+
+    def test_step3_save_draft_persists_complete_equipment_row(self):
+        """A fully-filled equipment row saves alongside the service modality."""
+        url = reverse('applications:edit_step3', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'action': 'save_draft',
+            'service_modality': 'self_service',
+            'specialization_area': 'preclinical',
+            'requested_access-TOTAL_FORMS': '1',
+            'requested_access-INITIAL_FORMS': '0',
+            'requested_access-MIN_NUM_FORMS': '0',
+            'requested_access-MAX_NUM_FORMS': '1000',
+            'requested_access-0-id': '',
+            'requested_access-0-equipment': str(self.equipment.pk),
+            'requested_access-0-hours_requested': '12',
+            'requested_access-0-DELETE': '',
+        })
+        self.assertRedirects(
+            resp, reverse('applications:my_applications'),
+            fetch_redirect_response=False,
+        )
+        self.app.refresh_from_db()
+        self.assertEqual(self.app.service_modality, 'self_service')
+        self.assertEqual(self.app.requested_access.count(), 1)
+        ra = self.app.requested_access.first()
+        self.assertEqual(ra.equipment_id, self.equipment.pk)
+        self.assertEqual(ra.hours_requested, Decimal('12'))
+
+    def test_step4_save_draft_persists_partial_text(self):
+        """A partial scientific-content textarea saves even with other fields blank."""
+        url = reverse('applications:edit_step4', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'action': 'save_draft',
+            'scientific_relevance': 'first draft of relevance section',
+            'methodology_description': '',
+            'expected_contributions': '',
+            'impact_strengths': '',
+            'socioeconomic_significance': '',
+            'opportunity_criteria': '',
+        })
+        self.assertRedirects(
+            resp, reverse('applications:my_applications'),
+            fetch_redirect_response=False,
+        )
+        self.app.refresh_from_db()
+        self.assertEqual(
+            self.app.scientific_relevance, 'first draft of relevance section'
+        )
+        self.assertEqual(self.app.methodology_description, '')
+
+    def test_step5_save_draft_without_data_consent(self):
+        """Step 5 normally requires data_consent — drafts don't."""
+        url = reverse('applications:edit_step5', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'action': 'save_draft',
+            'uses_animals': 'on',
+            'data_consent': '',
+        })
+        self.assertRedirects(
+            resp, reverse('applications:my_applications'),
+            fetch_redirect_response=False,
+        )
+        self.app.refresh_from_db()
+        self.assertTrue(self.app.uses_animals)
+        self.assertFalse(self.app.data_consent)
+
+    def test_step5_next_still_requires_data_consent(self):
+        """Next on step 5 still enforces the consent rule."""
+        url = reverse('applications:edit_step5', kwargs={'pk': self.app.pk})
+        resp = self.client.post(url, {
+            'uses_animals': '',
+            'data_consent': '',
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.app.refresh_from_db()
+        # Status should still be draft (not advanced).
+        self.assertEqual(self.app.status, 'draft')


### PR DESCRIPTION
## Summary
- **Bug:** The "Save Draft Application" button on wizard steps 2–5 was a plain `<a>` link to the dashboard, sitting outside the wizard `<form>`. Clicking it navigated away without POSTing, so any field edits since the last "Next" were silently lost. A real applicant lost work this way. The "automatically saved" banner copy on steps 1–4 compounded the problem by claiming an autosave that never existed.
- **Fix (Option 2 from the handoff):** Replace the link with a real `<button type="submit" name="action" value="save_draft">` inside each step's form. Each step view branches on `action=save_draft` and uses a relaxed-validation form variant (`ApplicationStep1DraftForm`…`ApplicationStep5DraftForm`) that marks every field optional and skips strict cross-field rules. The Next button continues to enforce full step validation as before; only the draft path is loosened.
- **Step 3 / formset:** The equipment formset still requires both `equipment` and `hours_requested` per row at the DB layer. In draft mode the formset's `validate_min` is disabled (so a user with no equipment yet can save modality choices), and partial rows surface a non-blocking warning instead of an error.

## Files touched
- `applications/forms.py` — `_DraftFormMixin` + five `*DraftForm` classes.
- `applications/views.py` — `_is_draft_save()` helper; each `application_edit_stepN` view picks the draft form when `action=save_draft` and redirects to `applications:my_applications` with a clear message.
- `templates/applications/wizard_step1-5.html` — banner copy now matches reality; steps 2–5 expose a real Save Draft submit button alongside Next.
- `templates/applications/preview.html` — the equivalent link is renamed to "Save and Continue Later" (the application is already saved at the preview page).
- `tests/test_wizard_save_draft.py` — new regression tests cover the draft happy path per step (including a complete equipment row in step 3), confirm Next still enforces validation on steps 2 and 5, and verify the data-consent rule still gates submission.

## Test plan
- [x] `python manage.py check` — clean.
- [x] `python manage.py test tests.test_wizard_save_draft` — 7/7 pass.
- [x] Pre-existing failing tests on `main` were verified unchanged (not introduced by this branch).
- [ ] Manual smoke test on dev: start a draft, fill some optional fields on step 2, click Save Draft → expect redirect to My Applications with success message; reopen the draft and confirm typed values persist.
- [ ] Manual smoke test on step 3: add a complete equipment row + service modality, click Save Draft → row + modality persist. Then add a partial equipment row (equipment, no hours), click Save Draft → service modality persists, partial row is dropped with a warning message.
- [ ] Manual smoke test on step 5: leave `data_consent` unchecked, click Save Draft → saves; click Next → still blocks with the consent error.

## Out of scope
- Submission flow and post-submit state machine — untouched.
- Cancel Application form — already a real `<form method="post">`, working correctly, left alone.
- Competitive-funding reject-protection rule from CLAUDE.md — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)